### PR TITLE
Independent horizontal and vertical edge distance

### DIFF
--- a/gridfinityBasket.scad
+++ b/gridfinityBasket.scad
@@ -91,8 +91,14 @@ WallPattern = 1; // [0:None, 1:HexGrid, 2:Grid]
 // Pattern feature size
 PatternSize = 8; // [4:0.5:15]
 
-// Minimum distance from pattern to start of basket outer corner
-PatternEdgeDist = 1.5; // [0:0.1:5]
+// Minimum distance from the top of the pattern to the start of the stacking lip
+PatternTopDist = 3; // [0:0.1:10]
+
+// Minimum distance from the bottom of the pattern to the baseplate
+PatternBotDist = 1.5; // [0:0.1:10]
+
+// Minimum distance from the pattern sides to the start of the basket outer corner
+PatternSideDist = 2; // [0:0.1:10]
 
 // Minimum distance between patterns
 PatternMinDist = 2; // [0.5:0.1:5]
@@ -394,9 +400,11 @@ module basket_wall() {
 
     // Size and position of the patterns
     pattern_height = total_height_mm - total_baseplate_height_mm - (WallThickness-MinWallThickness);
-    pattern_area_x = [(GridSize.x*BASEPLATE_DIMENSIONS.x)-(2*BASEPLATE_OUTER_RADIUS)+2*Padding-2*PatternEdgeDist, pattern_height-2*PatternEdgeDist];
-    pattern_area_y = [(GridSize.y*BASEPLATE_DIMENSIONS.y)-(2*BASEPLATE_OUTER_RADIUS)+2*Padding-2*PatternEdgeDist, pattern_height-2*PatternEdgeDist];
-    pattern_corner = [WallThickness+BASEPLATE_OUTER_RADIUS+PatternEdgeDist, total_baseplate_height_mm+PatternEdgeDist];
+    pattern_area_x = [  (GridSize.x*BASEPLATE_DIMENSIONS.x)-(2*BASEPLATE_OUTER_RADIUS)+2*Padding-2*PatternSideDist, 
+                        pattern_height-(PatternTopDist+PatternBotDist)];
+    pattern_area_y = [  (GridSize.y*BASEPLATE_DIMENSIONS.y)-(2*BASEPLATE_OUTER_RADIUS)+2*Padding-2*PatternSideDist, 
+                        pattern_height-(PatternTopDist+PatternBotDist)];
+    pattern_corner = [WallThickness+BASEPLATE_OUTER_RADIUS+PatternSideDist, total_baseplate_height_mm+PatternBotDist];
 
     difference() {
         // create the outer wall


### PR DESCRIPTION
Splitted up the PatternEdgeDist into PatternTopDist, PatternBotDist and PatternSideDist. This for example now makes it possible to have more distance from the pattern to the start of the stacking lip at the top, without having to decrease the pattern area in the horizontal direction. Below are some example images:

##### PatternBotDist=0, PatternTopDist=0, PatternSideDist=0
![0distance](https://github.com/user-attachments/assets/688524f2-fa72-4c5b-aa80-8845f6f965c7)

##### PatternBotDist=2, PatternTopDist=10, PatternSideDist=0
![2bot10topdistance](https://github.com/user-attachments/assets/8ff59897-cfa8-44a8-a312-91b13a5acb4f)

##### PatternBotDist=0, PatternTopDist=0, PatternSideDist=10
![10sidedistance](https://github.com/user-attachments/assets/e71decc1-9a98-4118-9bd0-d518f8c90d69)


